### PR TITLE
F51-157 Update Auth.Logout()

### DIFF
--- a/src/app/common/config/ordercloud-angular-sdk/ordercloud-angular-sdk.js
+++ b/src/app/common/config/ordercloud-angular-sdk/ordercloud-angular-sdk.js
@@ -10,10 +10,11 @@ function OrderCloudAngularSDKConfig(OrderCloudSDK, ocAppName, apiurl, authurl) {
 }
 
 function OrderCloudSDKAuthAdditions($provide) {
-    $provide.decorator('OrderCloudSDK', function($delegate, $cookies, $state) {
+    $provide.decorator('OrderCloudSDK', function($delegate, $cookies, $state, ocAppName) {
         function orderCloudAuthLogout() {
+            var cookiePrefix = ocAppName.Watch().replace(/ /g, '_').toLowerCase();
             angular.forEach($cookies.getAll(), function(value, key) {
-                $cookies.remove(key);
+                if (key.indexOf(cookiePrefix) > -1) $cookies.remove(key);
             });
             $state.go('login');
         }


### PR DESCRIPTION
Only remove cookies that have the application's cookiePrefix
The cookiePrefix is `ocAppName.Watch().replace(/ /g, '_').toLowerCase();`