### PR TITLE
chore: upgrade require-dir to 0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "gulp-uglify": "1.5.1",
     "gulp-wrapper": "1.0.0",
     "main-bower-files": "2.11.1",
-    "require-dir": "0.3.0",
+    "require-dir": "0.3.2",
     "yargs": "6.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
this version is compatible with node8/npm5