### PR TITLE
F51-27 - Related products updates

### DIFF
--- a/src/app/messageSenders/tests/messageSenders.spec.js
+++ b/src/app/messageSenders/tests/messageSenders.spec.js
@@ -1,0 +1,1 @@
+//TODO: Create unit tests for message senders

--- a/src/app/productManagement/product/js/product.controller.js
+++ b/src/app/productManagement/product/js/product.controller.js
@@ -1,7 +1,7 @@
 angular.module('orderCloud')
     .controller('ProductCtrl', ProductController);
 
-function ProductController($rootScope, $state, toastr, OrderCloudSDK, ocProducts, ocNavItems, ocProductPricing, SelectedProduct) {
+function ProductController($rootScope, $state, toastr, OrderCloudSDK, ocProducts, ocNavItems, ocRelatedProducts, ocProductPricing, SelectedProduct) {
     var vm = this;
     vm.model = angular.copy(SelectedProduct);
     vm.productName = angular.copy(SelectedProduct.Name);
@@ -33,6 +33,17 @@ function ProductController($rootScope, $state, toastr, OrderCloudSDK, ocProducts
         var partial = _.pick(vm.model, ['ID', 'Name', 'Description', 'QuantityMultiplier', 'Inventory', 'Active']);
         vm.loading = OrderCloudSDK.Products.Patch(SelectedProduct.ID, partial)
             .then(function (data) {
+
+                //Account for changes in ID
+                if (data.ID !== SelectedProduct.ID) {
+                    $state.go('.', {productid: data.ID}, {notify: false});
+
+                    //Sync other products that have this product in xp.RelatedProducts array
+                    //This only makes API calls if the product has related products
+                    ocRelatedProducts.Sync(data.xp.RelatedProducts, data.ID, SelectedProduct.ID);
+                }
+
+                //Update the view model
                 vm.model = angular.copy(data);
                 if (currentPrice && data.Name !== SelectedProduct.Name) {
                     OrderCloudSDK.PriceSchedules.Patch(currentPrice.ID, {
@@ -44,6 +55,8 @@ function ProductController($rootScope, $state, toastr, OrderCloudSDK, ocProducts
                 } else {
                     vm.model.DefaultPriceSchedule = currentPrice;
                 }
+
+
                 vm.productName = angular.copy(data.Name);
                 vm.inventoryEnabled = angular.copy(data.InventoryEnabled);
                 SelectedProduct = data;
@@ -73,10 +86,6 @@ function ProductController($rootScope, $state, toastr, OrderCloudSDK, ocProducts
                 });
             });
     }
-
-    $rootScope.$on('ProductManagement:SpecCountChanged', function (event, action) {
-        vm.model.SpecCount += (action == 'increment') ? 1 : -1;
-    });
 
     $rootScope.$on('OC:DefaultPriceUpdated', function (event, newID) {
         vm.model.DefaultPriceScheduleID = newID;

--- a/src/app/productManagement/product/js/product.controller.js
+++ b/src/app/productManagement/product/js/product.controller.js
@@ -31,6 +31,9 @@ function ProductController($rootScope, $state, toastr, OrderCloudSDK, ocProducts
     function updateProduct() {
         var currentPrice = angular.copy(vm.model.DefaultPriceSchedule);
         var partial = _.pick(vm.model, ['ID', 'Name', 'Description', 'QuantityMultiplier', 'Inventory', 'Active']);
+        var partialXP = _.pick(vm.model.xp, ['Featured']);
+        partial.xp = partialXP;
+
         vm.loading = OrderCloudSDK.Products.Patch(SelectedProduct.ID, partial)
             .then(function (data) {
 

--- a/src/app/productManagement/product/templates/product.html
+++ b/src/app/productManagement/product/templates/product.html
@@ -78,8 +78,8 @@
                             <button type="submit" cg-busy="product.productUpdateLoading" ng-disabled="product.form.$invalid" class="btn btn-primary btn-block">Update Product Info</button>
                         </div>
                         <div class="col-sm-offset-3 col-sm-9 hidden-xs">
-                        <hr>
-                            <button type="submit" class="btn btn-danger btn-block" ng-click="product.deleteProduct()">Delete Product</button>
+                            <hr>
+                            <button type="button" class="btn btn-danger btn-block" ng-click="product.deleteProduct()">Delete Product</button>
                         </div>
                     </fieldset>
                 </form>
@@ -93,7 +93,7 @@
         </div>
         <div class="visible-xs" oc-if-roles="ProductAdmin">
             <hr>
-            <button type="submit" class="btn btn-danger btn-block" ng-click="product.deleteProduct()"><i class="fa fa-trash-o"></i> Delete Product</button>
+            <button type="button" class="btn btn-danger btn-block" ng-click="product.deleteProduct()"><i class="fa fa-trash-o"></i> Delete Product</button>
         </div>
     </div>
 </article>

--- a/src/app/productManagement/products/js/products.service.js
+++ b/src/app/productManagement/products/js/products.service.js
@@ -2,7 +2,7 @@ angular.module('orderCloud')
     .factory('ocProducts', OrderCloudProducts)
 ;
 
-function OrderCloudProducts($q, $uibModal, ocConfirm, OrderCloudSDK) {
+function OrderCloudProducts($q, $uibModal, ocConfirm, OrderCloudSDK, ocRelatedProducts) {
     var service = {
         Create: _create,
         CreateDefaultPrice: _createDefaultPrice,
@@ -52,7 +52,10 @@ function OrderCloudProducts($q, $uibModal, ocConfirm, OrderCloudSDK) {
                 confirmText: 'Delete product',
                 type: 'delete'})
             .then(function() {
-                return OrderCloudSDK.Products.Delete(product.ID);
+                return OrderCloudSDK.Products.Delete(product.ID)
+                    .then(function() {
+                        return ocRelatedProducts.Sync(product.xp.RelatedProducts, null, product.ID);
+                    });
             });
     }
 

--- a/src/app/productManagement/relatedProducts/js/relatedProducts.config.js
+++ b/src/app/productManagement/relatedProducts/js/relatedProducts.config.js
@@ -5,7 +5,7 @@ angular.module('orderCloud')
 function RelatedProductConfig($stateProvider) {
     $stateProvider
         .state('product.relatedProducts', {
-            url: '/related-products?page&pageSize',
+            url: '/related-products?search&page&pageSize&searchOn&sortBy',
             templateUrl: 'productManagement/relatedProducts/templates/relatedProducts.html',
             controller: 'RelatedProductsCtrl',
             controllerAs: 'relatedProducts',
@@ -13,28 +13,8 @@ function RelatedProductConfig($stateProvider) {
                 Parameters: function($stateParams, ocParameters) {
                     return ocParameters.Get($stateParams);
                 },
-                ProductsList: function(OrderCloudSDK, SelectedProduct, Parameters) {
-                    return OrderCloudSDK.Products.List(Parameters)
-                        .then(function(products) {
-                            if (SelectedProduct.xp && SelectedProduct.xp.RelatedProducts && SelectedProduct.xp.RelatedProducts.length) {
-                                var relatedProductIDs = SelectedProduct.xp.RelatedProducts;
-                                    _.each(relatedProductIDs, function(id) {
-                                        var related = _.pluck(products.Items, 'ID').indexOf(id) > -1;
-                                        if (related) {
-                                            var relatedProduct = _.findWhere(products.Items, {ID: id});
-                                            relatedProduct.Related = true;
-                                            return relatedProduct;
-                                        }
-                                    })
-                                    var index = products.Items.findIndex(function(product) {
-                                        return product.ID === SelectedProduct.ID;
-                                    })
-                                    products.Items.splice(index, 1);
-                                    return products;
-                            } else {
-                                return products;
-                            }
-                        })
+                ProductList: function(SelectedProduct, Parameters, ocRelatedProducts) {
+                    return ocRelatedProducts.List(SelectedProduct, Parameters);
                 }
             }
         })

--- a/src/app/productManagement/relatedProducts/js/relatedProducts.controller.js
+++ b/src/app/productManagement/relatedProducts/js/relatedProducts.controller.js
@@ -2,46 +2,73 @@ angular.module('orderCloud')
     .controller('RelatedProductsCtrl', RelatedProductsController)
 ;
 
-function RelatedProductsController($q, OrderCloudSDK, toastr, $state, $exceptionHandler, ProductsList, SelectedProduct, Parameters) {
-    var vm = this;
-    vm.product = angular.copy(SelectedProduct);
-    vm.products = ProductsList;
+function RelatedProductsController(toastr, $state, ocParameters, ProductList, SelectedProduct, ocRelatedProducts, Parameters) {
+var vm = this;
+    vm.list = ProductList;
+    //Set parameters
     vm.parameters = Parameters;
+    //Sort by is a filter on mobile devices
+    vm.sortSelection = Parameters.sortBy ? (Parameters.sortBy.indexOf('!') == 0 ? Parameters.sortBy.split('!')[1] : Parameters.sortBy) : null;
+    //Check if search was used
+    vm.searchResults = Parameters.search && Parameters.search.length > 0;
 
-    vm.updateProduct = updateProduct;
-    vm.pageChanged = pageChanged;
-    vm.loadMore = loadMore;
+    vm.clearSearch =  clearSearch; //Clear the search parameter, reload the state & reset the page
+    vm.filter = filter; //Reload the state with new parameters
+    vm.loadMore = loadMore; //Load the next page of results with all of the same parameters
+    vm.pageChanged = pageChanged; //Reload the state with the incremented page parameter
+    vm.search = search; //Reload the state with new search parameter & reset the page
+    vm.updateSort = updateSort; //Conditionally set, reverse, remove the sortBy parameter & reload the state
+    vm.toggle = toggle;
 
-    function updateProduct(product) {
-        var relatedArr,
-            message;
-        if (product.Related) {
-            if (vm.product.xp && vm.product.xp.RelatedProducts && vm.product.xp.RelatedProducts.length) {
-                relatedArr = vm.product.xp.RelatedProducts;
-                relatedArr.push(product.ID);
-            } else {
-                related = product.ID;
-            }
-            message = product.Name + ' was added to related products';
-        } else {
-            relatedArr = _.without(vm.product.xp.RelatedProducts, product.ID);
-            message = product.Name + ' was removed from Related Products';
+    function toggle(scope) {
+        ocRelatedProducts.Toggle(scope.product)
+            .then(function(wasAdded) {
+                if (wasAdded) {
+                    toastr.success(scope.product.Name + ' was added to related products for ' + SelectedProduct.Name);
+                } else {
+                    toastr.success(scope.product.Name + ' was removed from related products for ' + SelectedProduct.Name);
+                }
+            });
+    }
+
+    function filter(resetPage) {
+        $state.go('.', ocParameters.Create(vm.parameters, resetPage));
+    }
+
+    function search() {
+        vm.filter(true);
+    }
+
+    function clearSearch() {
+        vm.parameters.search = null;
+        vm.filter(true);
+    }
+
+    function updateSort(value) {
+        value ? angular.noop() : value = vm.sortSelection;
+        switch(vm.parameters.sortBy) {
+            case value:
+                vm.parameters.sortBy = '!' + value;
+                break;
+            case '!' + value:
+                vm.parameters.sortBy = null;
+                break;
+            default:
+                vm.parameters.sortBy = value;
         }
-        OrderCloudSDK.Products.Patch(vm.product.ID, {xp: {RelatedProducts: relatedArr}})
-            .then(function() {
-                toastr.success(message, 'Success')
-            })
-            .catch(function(error) {
-                $exceptionHandler(error);
-            })
+        vm.filter(false);
     }
 
     function pageChanged() {
-        $state.go('product.relatedProducts', {page: vm.products.Meta.Page}, {reload: true});
+        $state.go('.', {page:vm.list.Meta.Page});
     }
 
     function loadMore() {
-        var parameters = angular.extend(Parameters, {page: vm.products.Meta.Page + 1});
-        return OrderCloudSDK.Products.List(parameters);
+        var parameters = angular.extend(Parameters, {page:vm.list.Meta.Page + 1});
+        return ocRelatedProducts.List(SelectedProduct, parameters)
+            .then(function(data) {
+                vm.list.Items = vm.list.Items.concat(data.Items);
+                vm.list.Meta = data.Meta;
+            });
     }
 }

--- a/src/app/productManagement/relatedProducts/js/relatedProducts.service.js
+++ b/src/app/productManagement/relatedProducts/js/relatedProducts.service.js
@@ -1,0 +1,147 @@
+angular.module('orderCloud')
+    .factory('ocRelatedProducts', OrderCloudRelatedProductsService)
+;
+
+function OrderCloudRelatedProductsService($q, $log, OrderCloudSDK) {
+    var service = {
+        List: _list, //Map a list of products to a desired products xp.RelatedProducts, all parameters are used.
+        Map: _map, //Manually map a product list response to an array of related product IDs (this will add a product.Related boolean)
+        Toggle: _toggle, //Add/remove a product to the product currently stored in currentProductID (initialized by the list method)
+        Sync: _sync //Sync an ID change of a product to it's related product's (xp.RelatedProducts array)
+    };
+
+    var relatedProducts,
+        currentProductID;        
+
+    function _hasRelatedProducts(product) {
+        return (product.xp && product.xp.RelatedProducts && Object.prototype.toString.call(product.xp.RelatedProducts) === '[object Array]' && product.xp.RelatedProducts.length);
+    }
+
+    function _list(product, parameters) {
+        if (!currentProductID || currentProductID !== product.ID) {
+            currentProductID = product.ID;
+            relatedProducts = (_hasRelatedProducts(product) ? _.compact(product.xp.RelatedProducts) : []);
+        }
+        var options = angular.extend(parameters, {filters:{ID:'!' + product.ID}});
+        return OrderCloudSDK.Products.List(options)
+            .then(function(data) {
+                return service.Map(data, relatedProducts);
+            });
+    }
+
+    function _map(productList, relatedProducts) {
+        if (!relatedProducts || !relatedProducts.length) return productList;
+        angular.forEach(productList.Items, function(product) {
+            product.Related = _.filter(relatedProducts, function(relatedID) {return relatedID === product.ID;}).length > 0;
+        });
+        return productList;
+    }
+
+    function _toggle(product) {
+        var df = $q.defer();
+        var newRelatedProducts = angular.copy(relatedProducts),
+            newOtherRelatedProducts = _hasRelatedProducts(product) ? _.compact(product.xp.RelatedProducts) : [],
+            shouldUpdateOther = true,
+            wasAdded;
+
+        function _updateRelatedProductsArray(array, productID, shouldMatch) {
+            var index = array.indexOf(productID);
+            if (shouldMatch) {
+                if (wasAdded && index === -1) {
+                    array.push(productID);
+                } else if (!wasAdded && index > -1) {
+                    array.splice(index, 1);
+                } else {
+                    shouldUpdateOther = false;
+                }
+            } else if (index > -1) {
+                array.splice(index, 1);
+                wasAdded = false;
+            } else {
+                array.push(productID);
+                wasAdded = true;
+            }
+        }
+
+        _updateRelatedProductsArray(newRelatedProducts, product.ID, false);
+        _updateRelatedProductsArray(newOtherRelatedProducts, currentProductID, true);
+
+        OrderCloudSDK.Products.Patch(currentProductID, {xp: {RelatedProducts: newRelatedProducts}})
+            .then(function() {
+                if (shouldUpdateOther) {
+                    OrderCloudSDK.Products.Patch(product.ID, {xp: {RelatedProducts: newOtherRelatedProducts}})
+                        .then(function() {
+                            relatedProducts = newRelatedProducts;
+                            df.resolve(wasAdded);
+                        });
+                } else {
+                    relatedProducts = newRelatedProducts;
+                    df.resolve(wasAdded);
+                }
+            })
+            .catch(function(ex) {
+                df.reject(ex);
+            });
+
+        return df.promise;
+    }
+
+    function _sync(relatedProductIDs, newProductID, oldProductID) {
+        var df = $q.defer(),
+            queue = [];
+
+        if (!(relatedProductIDs || relatedProductIDs.length))  {
+            df.resolve();
+        } else {
+            OrderCloudSDK.Products.List({filters: {ID:relatedProductIDs.join('|')}})
+                .then(function(data) {
+                    _createUpdateQueue(data.Items);
+                    $q.all(queue)
+                        .then(function(results) {
+                            angular.forEach(results, function(r) {
+                                if (!r.Success) $log('Related products sync on ' + oldProductID + '=>' + newProductID + ' failed for ' + r.ProductID);
+                            });
+                            df.resolve();
+                        });
+                });
+        }
+
+
+        function _createUpdateQueue(relatedProducts) {
+            angular.forEach(relatedProducts, function(product) {
+                var newArray;
+                if (!_hasRelatedProducts(product)) {
+                    newArray = [newProductID];
+                } else if (_oldProductPresent(product)) {
+                    newArray = angular.copy(product.xp.RelatedProducts);
+                    newArray[newArray.indexOf(oldProductID)] = newProductID;
+                } else {
+                    newArray = angular.copy(product.xp.RelatedProducts);
+                    newArray.push(newProductID);
+                }
+                queue.push(_updateXP(product.ID, _.compact(newArray)));
+            });
+        }
+
+        function _updateXP(productID, relatedProductsArray) {
+            var defer = $q.defer();
+            OrderCloudSDK.Products.Patch(productID, {xp: {RelatedProducts:relatedProductsArray}})
+                .then(function() {
+                    defer.resolve({ProductID: productID, Success:true});
+                })
+                .catch(function() {
+                    defer.resolve({ProductID: productID, Success:false});
+                });
+
+            return defer.promise;
+        }
+
+        function _oldProductPresent(product) {
+            return (product.xp.RelatedProducts.indexOf(oldProductID) > -1);
+        }
+
+        return df.promise;
+    }
+
+    return service;
+}

--- a/src/app/productManagement/relatedProducts/js/relatedProducts.service.js
+++ b/src/app/productManagement/relatedProducts/js/relatedProducts.service.js
@@ -90,7 +90,7 @@ function OrderCloudRelatedProductsService($q, $log, OrderCloudSDK) {
         var df = $q.defer(),
             queue = [];
 
-        if (!(relatedProductIDs || relatedProductIDs.length))  {
+        if (!relatedProductIDs || (relatedProductIDs && !relatedProductIDs.length))  {
             df.resolve();
         } else {
             OrderCloudSDK.Products.List({filters: {ID:relatedProductIDs.join('|')}})

--- a/src/app/productManagement/relatedProducts/templates/relatedProducts.html
+++ b/src/app/productManagement/relatedProducts/templates/relatedProducts.html
@@ -1,73 +1,91 @@
-<div class="row">
-    <div class="col-sm-12">
-        <h4>Related Products  <span class="badge">{{relatedProducts.products.Meta.TotalCount || 0}}</span></h4>
-        <!--====== LIST ======-->
-    <div cg-busy="relatedProducts.searchLoading">
-        <div class="no-matches" ng-if="!relatedProducts.products.Items.length">
-            <b ng-if="relatedProducts.searchResults">No matches found.</b>
-            <b ng-if="!relatedProducts.searchResults">This seller organization does not have any relatedProducts.</b>
-        </div>
-        <div ng-if="relatedProducts.products.Items.length">
-            <div class="row">
-                <div class="col-xs-6 col-xs-offset-6">
-                    <p class="text-right">{{(application.$ocMedia('min-width:768px') ? relatedProducts.products.Meta.ItemRange[0] : '1') + ' - ' +
-                        relatedProducts.products.Meta.ItemRange[1] + ' of ' + relatedProducts.products.Meta.TotalCount + ' results'}}</p>
-                </div>
-            </div>
+<header class="l-page-header">
+    <h3 class="l-page-header__title">
+        Related Products
+    </h3>
+</header>
 
-            <div class="panel panel-default table-responsive">
-                <table class="table table-striped table-bordered l-product-table">
-                    <colgroup>
-                        <col>
-                        <col>
-                        <col>
-                        <col oc-if-roles="ProductAdmin">
-                    </colgroup>
-                    <thead>
-                    <tr>
-                        <th ng-click="relatedProducts.updateSort('ID')">
-                            ID
-                            <i class="fa fa-caret-down" ng-show="relatedProducts.parameters.sortBy == 'ID'"></i>
-                            <i class="fa fa-caret-up" ng-show="relatedProducts.parameters.sortBy == '!ID'"></i>
-                        </th>
-                        <th ng-click="relatedProducts.updateSort('Name')">
-                            Name
-                            <i class="fa fa-caret-down" ng-show="relatedProducts.parameters.sortBy == 'Name'"></i>
-                            <i class="fa fa-caret-up" ng-show="relatedProducts.parameters.sortBy == '!Name'"></i>
-                        </th>
-                        <th>Active</th>
-                        <th oc-if-roles="ProductAdmin"></th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr ng-repeat="product in relatedProducts.products.Items">
-                        <td>{{product.ID}}</td>
-                        <td><a href="" ui-sref="product({productid:product.ID})">{{product.Name}}</a></td>
-                        <td class="text-center">
-                            <i class="fa fa-circle" aria-hidden="true" ng-class="{'active':product.Active}"></i>
-                        </td>
-                        <td class="text-center">
-                            <input id="relatedProductCheckbox" name="relatedProductCheckbox" type="checkbox" ng-model="product.Related" ng-change="relatedProducts.updateProduct(product)"/>
-                        </td>
-                    </tr>
-                    </tbody>
-                </table>
+<!--====== SEARCH/FILTERS ======-->
+<div ng-if="relatedProducts.list.Items.length || (!relatedProducts.list.Items.length && relatedProducts.searchResults)">
+    <form name="relatedProducts.searchForm" oc-pretty-submit>
+        <fieldset class="form-group">
+            <div class="input-group">
+                <span class="input-group-addon">
+                    <i class="fa fa-search"></i>
+                </span>
+                <input type="search" ng-change="relatedProducts.search()" ng-model-options="{debounce:1000}" placeholder="Search Products..." ng-model="relatedProducts.parameters.search" class="form-control">
+                <span ng-if="relatedProducts.searchResults" class="input-group-btn">
+                    <button class="btn btn-default" type="button" aria-label="Clear Search" ng-click="relatedProducts.clearSearch()"><i class="fa fa-times"></i> <span class="hidden-xs">Clear</span></button>
+                </span>
             </div>
-            <ul uib-pagination
-                class="pagination-sm pull-right hidden-xs"
-                ng-if="relatedProducts.products.Meta.TotalPages > 1"
-                total-items="relatedProducts.products.Meta.TotalCount"
-                items-per-page="relatedProducts.products.Meta.PageSize"
-                max-size="5"
-                boundary-links="relatedProducts.products.Meta.TotalPages > 5"
-                ng-model="relatedProducts.products.Meta.Page"
-                ng-change="relatedProducts.pageChanged()">
-            </ul>
-            <button type="button"
-                    class="btn btn-default btn-block btn-lg visible-xs"
-                    ng-show="relatedProducts.products.Meta.Page < relatedProducts.products.Meta.TotalPages"
-                    ng-click="relatedProducts.loadMore()">Load More</button>
-        </div>
+        </fieldset>
+    </form>
+</div>
+
+<!--====== LIST ======-->
+<div cg-busy="relatedProducts.searchLoading">
+    <div class="no-matches" ng-if="!relatedProducts.list.Items.length">
+        <b ng-if="relatedProducts.searchResults">No matches found.</b>
+        <b ng-if="!relatedProducts.searchResults">This seller organization does not have any other products.</b>
     </div>
+    <div ng-if="relatedProducts.list.Items.length">
+        <div class="row">
+            <div class="col-xs-6 col-xs-offset-6">
+                <p class="text-right">{{(application.$ocMedia('min-width:768px') ? relatedProducts.list.Meta.ItemRange[0] : '1') + ' - ' +
+                    relatedProducts.list.Meta.ItemRange[1] + ' of ' + relatedProducts.list.Meta.TotalCount + ' results'}}</p>
+            </div>
+        </div>
+
+        <div class="panel panel-default table-responsive">
+            <table class="table table-striped table-bordered l-product-table__related">
+                <colgroup>
+                    <col oc-if-roles="ProductAdmin">
+                    <col>
+                    <col>
+                    <col>
+                </colgroup>
+                <thead>
+                <tr>
+                    <th oc-if-roles="ProductAdmin"></th>
+                    <th ng-click="relatedProducts.updateSort('ID')">
+                        ID
+                        <i class="fa fa-caret-down" ng-show="relatedProducts.parameters.sortBy == 'ID'"></i>
+                        <i class="fa fa-caret-up" ng-show="relatedProducts.parameters.sortBy == '!ID'"></i>
+                    </th>
+                    <th ng-click="relatedProducts.updateSort('Name')">
+                        Name
+                        <i class="fa fa-caret-down" ng-show="relatedProducts.parameters.sortBy == 'Name'"></i>
+                        <i class="fa fa-caret-up" ng-show="relatedProducts.parameters.sortBy == '!Name'"></i>
+                    </th>
+                    <th>Active</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr ng-repeat="product in relatedProducts.list.Items">
+                    <td class="text-center">
+                        <input id="relatedProductCheckbox" name="relatedProductCheckbox" type="checkbox" ng-model="product.Related" ng-change="relatedProducts.toggle(this)"/>
+                    </td>
+                    <td>{{product.ID}}</td>
+                    <td><a href="" ui-sref="product.relatedProducts({productid:product.ID})">{{product.Name}}</a></td>
+                    <td class="text-center">
+                        <i class="fa fa-circle" aria-hidden="true" ng-class="{'active':product.Active}"></i>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+        <ul uib-pagination
+            class="pagination-sm pull-right hidden-xs"
+            ng-if="relatedProducts.list.Meta.TotalPages > 1"
+            total-items="relatedProducts.list.Meta.TotalCount"
+            items-per-page="relatedProducts.list.Meta.PageSize"
+            max-size="5"
+            boundary-links="relatedProducts.list.Meta.TotalPages > 5"
+            ng-model="relatedProducts.list.Meta.Page"
+            ng-change="relatedProducts.pageChanged()">
+        </ul>
+        <button type="button"
+                class="btn btn-default btn-block btn-lg visible-xs"
+                ng-show="relatedProducts.list.Meta.Page < relatedProducts.list.Meta.TotalPages"
+                ng-click="relatedProducts.loadMore()">Load More</button>
     </div>
 </div>

--- a/src/app/productManagement/specs/js/productsSpecs.controller.js
+++ b/src/app/productManagement/specs/js/productsSpecs.controller.js
@@ -34,7 +34,6 @@ function ProductSpecsController($rootScope, toastr, ocProductSpecs, ProductSpecs
             .then(function(assignment) {
                 vm.specs.Items.push(assignment);
                 vm.selectedSpec = assignment;
-                $rootScope.$broadcast('ProductManagement:SpecCountChanged', 'increment');
             });
     }
 
@@ -60,7 +59,6 @@ function ProductSpecsController($rootScope, toastr, ocProductSpecs, ProductSpecs
                 vm.specs.Items.splice(specIndex, 1);
                 toastr.success('Spec: ' + vm.selectedSpec.Spec.Name + ' was deleted.');
                 vm.selectedSpec = null;
-                $rootScope.$broadcast('ProductManagement:SpecCountChanged', 'decrement');
             });
     }
 

--- a/src/app/styles/layout/_product-table.less
+++ b/src/app/styles/layout/_product-table.less
@@ -123,3 +123,37 @@
     }
   }
 }
+
+.l-product-table__related {
+  @media(max-width:@screen-xs-max) {
+    col {
+      &:nth-child(2) {
+        width:99%;
+      }
+      &:nth-child(1) {
+        width:1%;
+      }
+    }
+    th,
+    td {
+      &:nth-child(2),
+      &:nth-child(4) {
+        display:none;
+      }
+      &:nth-child(3) {
+        border-right:none; //stops double borders from appearing
+      }
+    }
+  }
+  @media(min-width:@screen-sm-min) {
+    col {
+      &:nth-child(2) {
+        width:25%;
+      }
+      &:nth-child(1),
+      &:nth-child(4) {
+        width:1%;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Also includes F51-271 & F51-279
- There is a new service for listing, toggling, syncing, and mapping related products called `ocRelatedProducts`.
- You can now search and sort on the related products table
- The current product is filtered out of the related products list
- Changes to product ID are now synced to the products in it's `xp.RelatedProducts` array.
- Deleting a product will now sync the removal of that product ID from products in it's `xp.RelatedProducts` array