### PR TITLE
F51-594 - Add top level nav items to ocNavItems

### DIFF
--- a/src/app/base/js/base.controller.js
+++ b/src/app/base/js/base.controller.js
@@ -1,9 +1,19 @@
 angular.module('orderCloud')
     .controller('BaseCtrl', BaseController);
 
-function BaseController(CurrentUser, $state) {
+function BaseController(CurrentUser, $state, ocNavItems) {
     var vm = this;
     vm.currentUser = CurrentUser;
+    vm.navItemsLeft = ocNavItems.Filter(ocNavItems.TopNavLeft());
+    vm.navItemsRight = ocNavItems.Filter(ocNavItems.TopNavRight());
+
+    vm.isActive = function(activeWhen) {
+        var result = false;
+        angular.forEach(activeWhen, function(stateName) {
+            if ($state.includes(stateName)) result = true;
+        });
+        return result;
+    };
 
     vm.addContainerClass = function() {
         var result = false;

--- a/src/app/base/templates/base.tpl.html
+++ b/src/app/base/templates/base.tpl.html
@@ -15,43 +15,19 @@
         <!-- Collect the nav links, forms, and other content for toggling -->
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
             <ul class="nav navbar-nav">
-                <li ng-class="{active: application.$state.is('products') || application.$state.includes('product')}" oc-if-roles="ProductRoles">
-                    <a ng-click="base.selectNavItem('products')"><i class="fa fa-cube"></i> Products</a>
-                </li>
-                <li ng-class="{active: application.$state.is('catalogs') || application.$state.includes('catalog')}" oc-if-roles="CatalogRoles">
-                    <a ng-click="base.selectNavItem('catalogs')"><i class="fa fa-sitemap"></i> Catalogs</a>
-                </li>
-                <li ng-class="{active: application.$state.is('buyers') || application.$state.includes('buyer')}" oc-if-roles="{Items:['BuyerRoles', 'CatalogRoles'], Any:false}">
-                    <!--TODO: Add oc-if-roles="CatalogRoles"-->
-                    <a ng-click="base.selectNavItem('buyers')"><i class="fa fa-tags"></i> Buyers</a>
-                </li>
-                <li ng-class="{active: application.$state.is('orders') || application.$state.includes('orderDetail')}" oc-if-roles="{Items:['BuyerRoles', 'OrderRoles'], Any:false}">
-                    <a ng-click="base.selectNavItem('orders')"><i class="fa fa-inbox"></i> Orders</a>
+                <li ng-class="{active: base.isActive(navItem.activeWhen)}" ng-repeat="navItem in base.navItemsLeft">
+                    <a ng-click="base.selectNavItem(navItem.state)"><i class="fa {{navItem.icon}}"></i> {{navItem.name}}</a>
                 </li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li uib-dropdown oc-if-roles="{Items: ['SellerUserRoles', 'SellerUserGroupRoles', 'AddressRoles', 'SetSecurityProfile'], Any:true}">
-                    <a uib-dropdown-toggle role="button">Seller <span class="caret"></span></a>
-                    <ul class="dropdown-menu">
-                        <li ng-class="{active: application.$state.is('sellerUsers')}" oc-if-roles="SellerUserRoles">
-                            <a ng-click="base.selectNavItem('sellerUsers')"><i class="fa fa-user"></i> Users</a>
-                        </li>
-                        <li ng-class="{active: application.$state.is('sellerUserGroups') || application.$state.includes('adminUserGroup')}" oc-if-roles="SellerUserGroupRoles">
-                            <a ng-click="base.selectNavItem('sellerUserGroups')"><i class="fa fa-users"></i> User Groups</a>
-                        </li>
-                        <li ng-class="{active: application.$state.is('sellerAddresses')}" oc-if-roles="SellerAddressRoles">
-                            <a ng-click="base.selectNavItem('sellerAddresses')"><i class="fa fa-map-marker"></i> Addresses</a>
-                        </li>
-                        <li ng-class="{active: application.$state.is('permissions')}" oc-if-roles="SetSecurityProfile">
-                            <a ng-click="base.selectNavItem('permissions')"><i class="fa fa-lock"></i> Permissions</a>
-                        </li>
-                        <li ui-sref-active="active" oc-if-roles="MessageConfigAssignmentAdmin">
-                            <a href="" ui-sref="sellerMessageSenders"><i class="fa fa-bell"></i> Notifications</a>
+                <li uib-dropdown ng-class="{active: base.isActive(navItem.activeWhen)}" ng-repeat="navItem in base.navItemsRight">
+                    <a ng-if="!navItem.dropdown || (navItem.dropdown && !navItem.dropdown.length)" ng-click="base.selectNavItem(navItem.state)"><i class="fa {{navItem.icon}}"></i> {{navItem.name}}</a>
+                    <a ng-if="navItem.dropdown && navItem.dropdown.length" uib-dropdown-toggle role="button">{{navItem.name}} <span class="caret"></span></a>
+                    <ul class="dropdown-menu" ng-if="navItem.dropdown && navItem.dropdown.length">
+                        <li ng-class="{active: base.isActive(ddItem.activeWhen)}" ng-repeat="ddItem in navItem.dropdown">
+                            <a ng-click="base.selectNavItem(ddItem.state)"><i class="fa {{ddItem.icon}}"></i> {{ddItem.name}}</a>
                         </li>
                     </ul>
-                </li>
-                <li ng-class="{active: application.$state.is('account')}">
-                    <a ng-click="base.selectNavItem('account')"><i class="fa fa-user-circle-o"></i> <span class="hidden-sm hidden-md hidden-lg">My Account</span></a>
                 </li>
             </ul>
         </div>

--- a/src/app/common/services/oc-nav-items/oc-nav-items.js
+++ b/src/app/common/services/oc-nav-items/oc-nav-items.js
@@ -4,6 +4,8 @@ angular.module('orderCloud')
 
 function OrderCloudNavItemsService(ocRoles) {
     var service = {
+        TopNavRight: _topNavRight,
+        TopNavLeft: _topNavLeft,
         Product: _product,
         Catalog: _catalog,
         Buyer: _buyer,
@@ -11,6 +13,117 @@ function OrderCloudNavItemsService(ocRoles) {
         Order: _order,
         Filter: _filterNavItems
     };
+
+    function _topNavLeft() {
+        return [{
+                icon: 'fa-cube',
+                state: 'products',
+                name: 'Products',
+                activeWhen: ['products', 'product'],
+                roles: {
+                    Items: ['ProductRoles'],
+                    Any: false
+                }
+            },
+            {
+                icon: 'fa-sitemap',
+                state: 'catalogs',
+                name: 'Catalogs',
+                activeWhen: ['catalogs', 'catalog'],
+                roles: {
+                    Items: ['CatalogRoles'],
+                    Any: false
+                }
+            },
+            {
+                icon: 'fa-tags',
+                state: 'buyers',
+                name: 'Buyers',
+                activeWhen: ['buyers', 'buyer'],
+                roles: {
+                    Items: ['CatalogRoles', 'BuyerRoles'],
+                    Any: false
+                }
+            },
+            {
+                icon: 'fa-inbox',
+                state: 'orders',
+                name: 'Orders',
+                activeWhen: ['orders', 'orderDetail'],
+                roles: {
+                    Items: ['BuyerRoles', 'OrderRoles'],
+                    Any: false
+                }
+            }];
+    }
+
+    
+    function _topNavRight() {
+        return [{
+                name: 'Seller',
+                activeWhen: ['sellerUsers', 'sellerUserGroups', 'sellerUserGroup', 'sellerAddresses', 'permissions', 'sellerMessageSenders'],
+                roles: {
+                    Items: ['SellerUserRoles', 'SellerUserGroupRoles', 'AddressRoles', 'SetSecurityProfile', 'MessageConfigAssignmentAdmin'],
+                    Any: false
+                },
+                dropdown: [{
+                    icon: 'fa-user',
+                    state: 'sellerUsers',
+                    name: 'Users',
+                    activeWhen: ['sellerUsers'],
+                    roles: {
+                        Items: ['SellerUserRoles'],
+                        Any: false
+                    }
+                },
+                {
+                    icon: 'fa-users',
+                    state: 'sellerUserGroups',
+                    name: 'User Groups',
+                    activeWhen: ['sellerUserGroups', 'sellerUserGroup'],
+                    roles: {
+                        Items: ['SellerUserGroupRoles'],
+                        Any: false
+                    }
+                },
+                {
+                    icon: 'fa-map-marker',
+                    state: 'sellerAddresses',
+                    name: 'Addresses',
+                    activeWhen: ['sellerAddresses'],
+                    roles: {
+                        Items: ['SellerAddressRoles'],
+                        Any: false
+                    }
+                },
+                {
+                    icon: 'fa-lock',
+                    state: 'permissions',
+                    name: 'Permissions',
+                    activeWhen: ['permissions'],
+                    roles: {
+                        Items: ['SetSecurityProfile'],
+                        Any: false
+                    }
+                },
+                {
+                    icon: 'fa-bell',
+                    state: 'sellerMessageSenders',
+                    name: 'Notifications',
+                    activeWhen: ['sellerMessageSenders'],
+                    roles: {
+                        Items: ['MessageConfigAssignmentAdmin'],
+                        Any: false
+                    }
+                }]
+            },
+            {
+                icon: 'fa-user-circle-o',
+                state: 'account',
+                name: 'Account',
+                activeWhen: ['account']
+            }];
+    }
 
 
     function _product() {
@@ -390,6 +503,11 @@ function OrderCloudNavItemsService(ocRoles) {
     function _filterNavItems(navItems) {
         return _.filter(navItems, function (navItem) {
             if (!navItem.roles) return true;
+            if (navItem.dropdown && navItem.dropdown.length) {
+                navItem.dropdown = _.filter(navItem.dropdown, function(ni) {
+                    return ocRoles.UserIsAuthorized(ni.roles.Items, ni.roles.any);
+                });
+            }
             return ocRoles.UserIsAuthorized(navItem.roles.Items, navItem.roles.any);
         });
     }


### PR DESCRIPTION
There are two new methods on ocNavItems:
- `ocNavItems.TopNavLeft`
- `ocNavItems.TopNavRight`

These include the navigation items that are being repeated over in the updated base.html.
The ocNavItems.Filter() method has been updated to filter dropdown menu items.